### PR TITLE
Bugfix for infinite confetti fx

### DIFF
--- a/pages/competition.vue
+++ b/pages/competition.vue
@@ -230,6 +230,9 @@ export default {
     //   this.startConfettiRain()
     // }
   },
+  beforeDestroy () {
+    this.$confetti.remove()
+  },
   methods: {
     getTimer () {
     //   const date = new Date(this.competitionEndDate - this.currentTime * 1000)


### PR DESCRIPTION
Confetti FX was never ending. Even when switching pages, the animation kept playing. Removed effect on beforeDestroy